### PR TITLE
Add Object Subscripting to links

### DIFF
--- a/DeepLinkSDK/DeepLink/DPLDeepLink.h
+++ b/DeepLinkSDK/DeepLink/DPLDeepLink.h
@@ -40,4 +40,17 @@
  */
 @property (nonatomic, strong, readonly) NSURL *callbackURL;
 
+///--------------------------------------------------
+/// @name Parameter Retrieval via Object Subscripting
+///--------------------------------------------------
+
+/**
+ Both query and route parameters can be accessed concisely with object subscripting.
+ @code
+ id username = deepLink[@"username"];
+ @endcode
+ @note If the key is contained in both queryParameters and routeParameters, the value from queryParameters is returned.
+ */
+- (id)objectForKeyedSubscript:(id <NSCopying>)key;
+
 @end

--- a/DeepLinkSDK/DeepLink/DPLDeepLink.m
+++ b/DeepLinkSDK/DeepLink/DPLDeepLink.m
@@ -47,6 +47,15 @@ static NSString * const DPLCallbackURLKey = @"dpl_callback_url";
 }
 
 
+- (id)objectForKeyedSubscript:(id <NSCopying>)key {
+    id value = _queryParameters[key];
+    if (!value) {
+        value = _routeParameters[key];
+    }
+    return value;
+}
+
+
 - (NSString *)description {
     return [NSString stringWithFormat:
             @"\n<%@ %p\n"

--- a/SampleApps/ReceiverDemo/DPLReceiverAppDelegate.m
+++ b/SampleApps/ReceiverDemo/DPLReceiverAppDelegate.m
@@ -24,8 +24,8 @@
     self.router[@"product/:sku"] = [DPLProductRouteHandler class];
     
     self.router[@"/say/:title/:message"] = ^(DPLDeepLink *link) {
-        [[[UIAlertView alloc] initWithTitle:link.routeParameters[@"title"]
-                                    message:link.routeParameters[@"message"]
+        [[[UIAlertView alloc] initWithTitle:link[@"title"]
+                                    message:link[@"message"]
                                    delegate:nil
                           cancelButtonTitle:NSLocalizedString(@"OK", nil)
                           otherButtonTitles:nil] show];


### PR DESCRIPTION
I'm working on integrating `ios-deeplink-sdk` into an app that uses many links.

I find my code cluttered with `link.routeParameters[@"something"]` and `link.queryParameters[@"something"]`.

I added object subscripting to my local fork to make this code more expressive. Perhaps you'll enjoy it in your project.

This allows, for example:

    self.router[@"/say/:title/:message"] = ^(DPLDeepLink *link) {
        [[[UIAlertView alloc] initWithTitle:link[@"title"]
                                    message:link[@"message"]
                                   delegate:nil
                          cancelButtonTitle:NSLocalizedString(@"OK", nil)
                          otherButtonTitles:nil] show];
    };
