### PR TITLE
Allow routes to be filtered by hosts

### DIFF
--- a/DeepLinkSDK/RouteMatcher/DPLRouteMatcher.m
+++ b/DeepLinkSDK/RouteMatcher/DPLRouteMatcher.m
@@ -4,6 +4,7 @@
 
 @interface DPLRouteMatcher ()
 
+@property (nonatomic, copy)   NSString *host;
 @property (nonatomic, copy)   NSString *route;
 @property (nonatomic, strong) NSArray  *routeParts;
 
@@ -23,7 +24,13 @@
     
     self = [super init];
     if (self) {
-        _route      = route;
+        NSUInteger hostIdx = [route rangeOfString:@"]"].location;
+        if ([route rangeOfString:@"["].location == 0 && hostIdx != NSNotFound) {
+            _host = [route substringWithRange:NSMakeRange(1, hostIdx - 1)];
+            _route = [route substringFromIndex:hostIdx + 1];
+        } else {
+            _route      = route;
+        }
         _routeParts = [_route componentsSeparatedByString:@"/"];
     }
     
@@ -37,6 +44,9 @@
     }
     
     DPLDeepLink *deepLink = [[DPLDeepLink alloc] initWithURL:url];
+    if (_host != nil && ![[deepLink.URL host] isEqualToString:_host]) {
+        return nil;
+    }
     
     NSArray *pathParts = [[[deepLink.URL path] DPL_trimPath] componentsSeparatedByString:@"/"];
     if ([pathParts count] != [self.routeParts count]) {

--- a/DeepLinkSDK/RouteMatcher/DPLRouteMatcher.m
+++ b/DeepLinkSDK/RouteMatcher/DPLRouteMatcher.m
@@ -5,7 +5,6 @@
 @interface DPLRouteMatcher ()
 
 @property (nonatomic, copy)   NSString *host;
-@property (nonatomic, copy)   NSString *route;
 @property (nonatomic, strong) NSArray  *routeParts;
 
 @end
@@ -24,14 +23,18 @@
     
     self = [super init];
     if (self) {
-        NSUInteger hostIdx = [route rangeOfString:@"]"].location;
-        if ([route rangeOfString:@"["].location == 0 && hostIdx != NSNotFound) {
-            _host = [route substringWithRange:NSMakeRange(1, hostIdx - 1)];
-            _route = [route substringFromIndex:hostIdx + 1];
+        NSUInteger firstSlash = [route rangeOfString:@"/"].location;
+        if (firstSlash == 0) {
+            route       = [route substringFromIndex:1];
+            _routeParts = [route componentsSeparatedByString:@"/"];
         } else {
-            _route      = route;
+            NSArray * routeParts = [route componentsSeparatedByString:@"/"];
+            _host = [routeParts objectAtIndex:0];
+            _routeParts = [routeParts subarrayWithRange:NSMakeRange(1, routeParts.count - 1)];
+            if ([_routeParts count] == 0) {
+                _routeParts = @[ @"" ];
+            }
         }
-        _routeParts = [_route componentsSeparatedByString:@"/"];
     }
     
     return self;

--- a/DeepLinkSDK/Router/DPLDeepLinkRouter.m
+++ b/DeepLinkSDK/Router/DPLDeepLinkRouter.m
@@ -2,7 +2,6 @@
 #import "DPLRouteMatcher.h"
 #import "DPLDeepLink.h"
 #import "DPLRouteHandler.h"
-#import "NSString+DPLTrim.h"
 #import "DPLErrors.h"
 #import <objc/runtime.h>
 
@@ -46,8 +45,6 @@
 
 - (void)registerHandlerClass:(Class <DPLRouteHandler>)handlerClass forRoute:(NSString *)route {
 
-    route = [route DPL_trimPath];
-    
     if (handlerClass && [route length]) {
         [self.routes addObject:route];
         [self.blocksByRoute removeObjectForKey:route];
@@ -58,8 +55,6 @@
 
 - (void)registerBlock:(DPLRouteHandlerBlock)routeHandlerBlock forRoute:(NSString *)route {
 
-    route = [route DPL_trimPath];
-    
     if (routeHandlerBlock && [route length]) {
         [self.routes addObject:route];
         [self.classesByRoute removeObjectForKey:route];

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Add deep link support to your app in 5 minutes or less following these simple st
 **3. Register a route handler**
 
 ````objc
-self.router[@"log/:message"] = ^(DPLDeepLink *link) {
+self.router[@"/log/:message"] = ^(DPLDeepLink *link) {
   NSLog(@"%@", link.routeParameters[@"message"]);
 };
 ````

--- a/SampleApps/ReceiverDemo/DPLReceiverAppDelegate.m
+++ b/SampleApps/ReceiverDemo/DPLReceiverAppDelegate.m
@@ -21,7 +21,7 @@
     self.router = [[DPLDeepLinkRouter alloc] init];
    
     // Route registration.
-    self.router[@"product/:sku"] = [DPLProductRouteHandler class];
+    self.router[@"/product/:sku"] = [DPLProductRouteHandler class];
     
     self.router[@"/say/:title/:message"] = ^(DPLDeepLink *link) {
         [[[UIAlertView alloc] initWithTitle:link.routeParameters[@"title"]

--- a/Tests/RouteMatcher/DPLRouteMatcherSpec.m
+++ b/Tests/RouteMatcher/DPLRouteMatcherSpec.m
@@ -11,70 +11,70 @@ SpecBegin(DPLRouteMatcher)
 describe(@"Matching Routes", ^{
     
     it(@"returns a deep link when a URL matches a route", ^{
-        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"table/book"];
+        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"/table/book"];
         NSURL *url = URLWithPath(@"/table/book");
         DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];
         expect(deepLink).toNot.beNil();
     });
     
     it(@"returns a deep link when a URL matches a host", ^{
-        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"[dpl.com]"];
+        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"dpl.com"];
         NSURL *url = URLWithPath(@"");
         DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];
         expect(deepLink).toNot.beNil();
     });
     
     it(@"does NOT return a deep link when a URL matches a host", ^{
-        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"[dpl2.com]"];
+        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"dpl2.com"];
         NSURL *url = URLWithPath(@"");
         DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];
         expect(deepLink).to.beNil();
     });
     
     it(@"returns a deep link when a URL matches a parameterized route", ^{
-        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"table/book/:id"];
+        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"/table/book/:id"];
         NSURL *url = URLWithPath(@"/table/book/abc123");
         DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];
         expect(deepLink).toNot.beNil();
     });
     
     it(@"does NOT return a deep link when the URL and route dont match", ^{
-        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"table/book"];
+        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"/table/book"];
         NSURL *url = URLWithPath(@"/table/book/abc123");
         DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];
         expect(deepLink).to.beNil();
     });
 
     it(@"does NOT return a deep link when the URL and parameterized route dont match", ^{
-        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"table/book/:id"];
+        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"/table/book/:id"];
         NSURL *url = URLWithPath(@"/table/book");
         DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];
         expect(deepLink).to.beNil();
     });
     
     it(@"does NOT return a deep link when the URL path does not match the route path", ^{
-        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"table/book/:id"];
+        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"/table/book/:id"];
         NSURL *url = URLWithPath(@"/ride/book");
         DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];
         expect(deepLink).to.beNil();
     });
     
     it(@"returns a deep link with route parameters when a URL matches a parameterized route", ^{
-        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"table/book/:id/:time"];
+        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"/table/book/:id/:time"];
         NSURL *url = URLWithPath(@"/table/book/abc123/1418931000");
         DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];
         expect(deepLink.routeParameters).to.equal(@{ @"id": @"abc123", @"time": @"1418931000" });
     });
     
     it(@"returns a deep link with route parameters when a URL matches a parameterized route for a specific host", ^{
-        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"[dpl.com]table/book/:id/:time"];
+        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"dpl.com/table/book/:id/:time"];
         NSURL *url = URLWithPath(@"/table/book/abc123/1418931000");
         DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];
         expect(deepLink.routeParameters).to.equal(@{ @"id": @"abc123", @"time": @"1418931000" });
     });
     
     it(@"does NOT return a deep link with route parameters when a URL matches a parameterized route for a specific host", ^{
-        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"[dpl2.com]table/book/:id/:time"];
+        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"dpl2.com/table/book/:id/:time"];
         NSURL *url = URLWithPath(@"/table/book/abc123/1418931000");
         DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];
         expect(deepLink).to.beNil();

--- a/Tests/RouteMatcher/DPLRouteMatcherSpec.m
+++ b/Tests/RouteMatcher/DPLRouteMatcherSpec.m
@@ -17,6 +17,20 @@ describe(@"Matching Routes", ^{
         expect(deepLink).toNot.beNil();
     });
     
+    it(@"returns a deep link when a URL matches a host", ^{
+        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"[dpl.com]"];
+        NSURL *url = URLWithPath(@"");
+        DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];
+        expect(deepLink).toNot.beNil();
+    });
+    
+    it(@"does NOT return a deep link when a URL matches a host", ^{
+        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"[dpl2.com]"];
+        NSURL *url = URLWithPath(@"");
+        DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];
+        expect(deepLink).to.beNil();
+    });
+    
     it(@"returns a deep link when a URL matches a parameterized route", ^{
         DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"table/book/:id"];
         NSURL *url = URLWithPath(@"/table/book/abc123");
@@ -50,6 +64,20 @@ describe(@"Matching Routes", ^{
         NSURL *url = URLWithPath(@"/table/book/abc123/1418931000");
         DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];
         expect(deepLink.routeParameters).to.equal(@{ @"id": @"abc123", @"time": @"1418931000" });
+    });
+    
+    it(@"returns a deep link with route parameters when a URL matches a parameterized route for a specific host", ^{
+        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"[dpl.com]table/book/:id/:time"];
+        NSURL *url = URLWithPath(@"/table/book/abc123/1418931000");
+        DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];
+        expect(deepLink.routeParameters).to.equal(@{ @"id": @"abc123", @"time": @"1418931000" });
+    });
+    
+    it(@"does NOT return a deep link with route parameters when a URL matches a parameterized route for a specific host", ^{
+        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"[dpl2.com]table/book/:id/:time"];
+        NSURL *url = URLWithPath(@"/table/book/abc123/1418931000");
+        DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];
+        expect(deepLink).to.beNil();
     });
 });
 

--- a/Tests/Router/DPLDeepLinkRouterSpec.m
+++ b/Tests/Router/DPLDeepLinkRouterSpec.m
@@ -95,9 +95,9 @@ describe(@"Registering Routes", ^{
         expect(router.classesByRoute).to.beEmpty();
     });
     
-    it(@"trims routes before registering", ^{
+    it(@"does NOT trim routes before registering", ^{
         router[@"/table/book/:id \n"] = [DPLRouteHandler class];
-        expect(router[route]).to.equal([DPLRouteHandler class]);
+        expect(router[route]).notTo.equal([DPLRouteHandler class]);
     });
 });
 
@@ -113,11 +113,11 @@ describe(@"Handling Routes", ^{
     
     it(@"matches more specfic routes first when they are registered first", ^{
         waitUntil(^(DoneCallback done) {
-            router[@"say/hello"] = ^(DPLDeepLink *deepLink) {
+            router[@"/say/hello"] = ^(DPLDeepLink *deepLink) {
                 expect(deepLink.routeParameters).to.beEmpty();
             };
             
-            router[@"say/:word"] = ^{
+            router[@"/say/:word"] = ^{
                 XCTFail(@"The wrong route was matched.");
             };
             
@@ -131,11 +131,11 @@ describe(@"Handling Routes", ^{
     
     it(@"matches less specfic routes first when they are registered first", ^{
         waitUntil(^(DoneCallback done) {
-            router[@"say/:word"] = ^(DPLDeepLink *deepLink) {
+            router[@"/say/:word"] = ^(DPLDeepLink *deepLink) {
                 expect(deepLink.routeParameters[@"word"]).to.equal(@"hello");
             };
             
-            router[@"say/hello"] = ^{
+            router[@"/say/hello"] = ^{
                 XCTFail(@"The wrong route was matched.");
             };
             
@@ -160,7 +160,7 @@ describe(@"Handling Routes", ^{
     it(@"produces an error when a route handler does not specify a target view controller", ^{
         waitUntil(^(DoneCallback done) {
             
-            router[@"say/:word"] = [DPLRouteHandler class];
+            router[@"/say/:word"] = [DPLRouteHandler class];
             
             [router handleURL:url withCompletion:^(BOOL handled, NSError *error) {
                 expect(handled).to.beFalsy();


### PR DESCRIPTION
Allow routes to be filtered by hosts, or allow a route to match only a host value.

For example 'twitter://timeline' would be matched with a route of '[timeline]'
http://wiki.akosma.com/IPhone_URL_Schemes#Twitter