### PR TITLE
Add regex support to DPLRouteMatcher

### DIFF
--- a/DeepLinkSDK/RouteMatcher/DPLRouteMatcher.m
+++ b/DeepLinkSDK/RouteMatcher/DPLRouteMatcher.m
@@ -2,8 +2,8 @@
 #import "DPLDeepLink_Private.h"
 #import "NSString+DPLTrim.h"
 
-static NSString * const DPLParameterRoutePattern = @":[a-zA-Z0-9-_]+";
-static NSString * const DPLParameterURLPattern = @"([a-zA-Z0-9-_]+)";
+static NSString * const DPLRouteParameterPattern = @":[a-zA-Z0-9-_]+";
+static NSString * const DPLURLParameterPattern = @"([a-zA-Z0-9-_]+)";
 
 @interface DPLRouteMatcher ()
 
@@ -37,7 +37,7 @@ static NSString * const DPLParameterURLPattern = @"([a-zA-Z0-9-_]+)";
 - (NSRegularExpression *)regex {
     if (!_regex) {
         _routeParamaterNames = [NSMutableArray array];
-        NSRegularExpression *parameterRegex = [NSRegularExpression regularExpressionWithPattern:DPLParameterRoutePattern
+        NSRegularExpression *parameterRegex = [NSRegularExpression regularExpressionWithPattern:DPLRouteParameterPattern
                                                                                         options:0
                                                                                           error:nil];
         
@@ -54,7 +54,7 @@ static NSString * const DPLParameterURLPattern = @"([a-zA-Z0-9-_]+)";
             [self.routeParamaterNames addObject:variableName];
             
             modifiedRoute = [modifiedRoute stringByReplacingOccurrencesOfString:stringToReplace
-                                                                     withString:DPLParameterURLPattern];
+                                                                     withString:DPLURLParameterPattern];
         }
         
         modifiedRoute = [modifiedRoute stringByAppendingString:@"$"];
@@ -79,11 +79,14 @@ static NSString * const DPLParameterURLPattern = @"([a-zA-Z0-9-_]+)";
         return nil;
     }
     
-    // Define route parameters in the routeParameters dictionary
+    // Set route parameters in the routeParameters dictionary
     NSMutableDictionary *routeParameters = [NSMutableDictionary dictionary];
     for (NSTextCheckingResult *result in matches) {
+        // Begin at 1 as first range is the whole match
         for (int i = 1; i < result.numberOfRanges && i <= self.routeParamaterNames.count; i++) {
-            routeParameters[self.routeParamaterNames[i - 1]] = [deepLinkString substringWithRange:[result rangeAtIndex:i]];
+            NSString *parameterName         = self.routeParamaterNames[i - 1];
+            NSString *parameterValue        = [deepLinkString substringWithRange:[result rangeAtIndex:i]];
+            routeParameters[parameterName]  = parameterValue;
         }
     }
     deepLink.routeParameters = routeParameters;

--- a/DeepLinkSDK/RouteMatcher/DPLRouteMatcher.m
+++ b/DeepLinkSDK/RouteMatcher/DPLRouteMatcher.m
@@ -2,11 +2,12 @@
 #import "DPLDeepLink_Private.h"
 #import "NSString+DPLTrim.h"
 
-static NSString * const DPLParameterRegexString = @":[a-zA-Z0-9-_]+";
+static NSString * const DPLParameterRoutePattern = @":[a-zA-Z0-9-_]+";
+static NSString * const DPLParameterURLPattern = @"([a-zA-Z0-9-_]+)";
 
 @interface DPLRouteMatcher ()
 
-@property (nonatomic, copy) NSString  *route;
+@property (nonatomic, copy)   NSString  *route;
 @property (nonatomic, strong) NSRegularExpression *regex;
 @property (nonatomic, strong) NSMutableArray *routeParamaterNames;
 
@@ -36,48 +37,53 @@ static NSString * const DPLParameterRegexString = @":[a-zA-Z0-9-_]+";
 - (NSRegularExpression *)regex {
     if (!_regex) {
         _routeParamaterNames = [NSMutableArray array];
-        NSRegularExpression *parameterRegex = [NSRegularExpression regularExpressionWithPattern:DPLParameterRegexString options:0 error:nil];
+        NSRegularExpression *parameterRegex = [NSRegularExpression regularExpressionWithPattern:DPLParameterRoutePattern
+                                                                                        options:0
+                                                                                          error:nil];
         
         __block NSString *modifiedRoute = [self.route copy];
-        [parameterRegex enumerateMatchesInString:self.route
-                                         options:0
-                                           range:NSMakeRange(0, self.route.length)
-                                      usingBlock:^(NSTextCheckingResult *result, NSMatchingFlags flags, BOOL *stop) {
-                                          NSString *stringToReplace = [self.route substringWithRange:result.range];
-                                          NSString *variableName = [stringToReplace stringByReplacingOccurrencesOfString:@":" withString:@""];
-                                          [self.routeParamaterNames addObject:variableName];
-                                          
-                                          NSString *replacementRegex = [NSString stringWithFormat:@"([a-zA-Z0-9-_]+)"];
-                                          
-                                          modifiedRoute = [modifiedRoute stringByReplacingOccurrencesOfString:stringToReplace withString:replacementRegex];
-                                      }];
+        NSArray *matches = [parameterRegex matchesInString:self.route
+                                                   options:0
+                                                     range:NSMakeRange(0, self.route.length)];
+        
+        for (NSTextCheckingResult *result in matches) {
+            
+            NSString *stringToReplace   = [self.route substringWithRange:result.range];
+            NSString *variableName      = [stringToReplace stringByReplacingOccurrencesOfString:@":"
+                                                                                     withString:@""];
+            [self.routeParamaterNames addObject:variableName];
+            
+            modifiedRoute = [modifiedRoute stringByReplacingOccurrencesOfString:stringToReplace
+                                                                     withString:DPLParameterURLPattern];
+        }
         
         modifiedRoute = [modifiedRoute stringByAppendingString:@"$"];
-        
-        _regex = [NSRegularExpression regularExpressionWithPattern:modifiedRoute options:0 error:nil];
+        _regex = [NSRegularExpression regularExpressionWithPattern:modifiedRoute
+                                                           options:0
+                                                             error:nil];
     }
+    
     return _regex;
 }
 
 
 - (DPLDeepLink *)deepLinkWithURL:(NSURL *)url {
-    if (!url) {
+    
+    DPLDeepLink *deepLink       = [[DPLDeepLink alloc] initWithURL:url];
+    NSString *deepLinkString    = [deepLink.URL absoluteString];
+    NSArray *matches            = [self.regex matchesInString:deepLinkString
+                                                      options:0
+                                                        range:NSMakeRange(0, deepLinkString.length)];
+    
+    if (!matches.count) {
         return nil;
     }
     
-    DPLDeepLink *deepLink = [[DPLDeepLink alloc] initWithURL:url];
-    
-    NSArray *matches = [self.regex matchesInString:[deepLink.URL absoluteString]
-                                           options:0
-                                             range:NSMakeRange(0, [deepLink.URL absoluteString].length)];
-    
-    if (![matches count]) {
-        return nil;
-    }
+    // Define route parameters in the routeParameters dictionary
     NSMutableDictionary *routeParameters = [NSMutableDictionary dictionary];
     for (NSTextCheckingResult *result in matches) {
         for (int i = 1; i < result.numberOfRanges && i <= self.routeParamaterNames.count; i++) {
-            routeParameters[self.routeParamaterNames[i - 1]] = [[deepLink.URL absoluteString] substringWithRange:[result rangeAtIndex:i]];
+            routeParameters[self.routeParamaterNames[i - 1]] = [deepLinkString substringWithRange:[result rangeAtIndex:i]];
         }
     }
     deepLink.routeParameters = routeParameters;

--- a/Tests/RouteMatcher/DPLRouteMatcherSpec.m
+++ b/Tests/RouteMatcher/DPLRouteMatcherSpec.m
@@ -101,6 +101,17 @@ describe(@"Matching Routes", ^{
         DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];
         expect(deepLink).to.beNil();
     });
+    
+    it(@"matches a wildcard deep link", ^{
+        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@".*"];
+        NSURL *url = URLWithPath(@"/table/book/abc123/1418931000");
+        NSURL *url2 = URLWithPath(@"/abc123");
+        DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];
+        expect(deepLink).notTo.beNil();
+
+        DPLDeepLink *deepLink2 = [matcher deepLinkWithURL:url2];
+        expect(deepLink2).notTo.beNil();
+    });
 });
 
 SpecEnd

--- a/Tests/RouteMatcher/DPLRouteMatcherSpec.m
+++ b/Tests/RouteMatcher/DPLRouteMatcherSpec.m
@@ -8,6 +8,7 @@ NSURL *URLWithPath(NSString *path) {
 
 SpecBegin(DPLRouteMatcher)
 
+
 describe(@"Matching Routes", ^{
     
     it(@"returns a deep link when a URL matches a route", ^{
@@ -27,6 +28,13 @@ describe(@"Matching Routes", ^{
     it(@"does NOT return a deep link when a host does NOT match the URL host", ^{
         DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"dpl2.com"];
         NSURL *url = URLWithPath(@"");
+        DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];
+        expect(deepLink).to.beNil();
+    });
+    
+    it(@"does NOT return a deep link when a host does NOT match and path does match", ^{
+        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"dpl2.com/table/:id"];
+        NSURL *url = URLWithPath(@"/table/abc123");
         DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];
         expect(deepLink).to.beNil();
     });


### PR DESCRIPTION
- Full regex support
- Existing functionality migrated to regex
- Wildcard routes supported with `@".*"`