### PR TITLE
Valid URLs can use ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0...

### DIFF
--- a/DeepLinkSDK/RouteMatcher/DPLRouteMatcher.m
+++ b/DeepLinkSDK/RouteMatcher/DPLRouteMatcher.m
@@ -70,7 +70,7 @@ static NSString * const DPLURLParameterPattern = @"([^/]+)";
 - (DPLDeepLink *)deepLinkWithURL:(NSURL *)url {
     
     DPLDeepLink *deepLink       = [[DPLDeepLink alloc] initWithURL:url];
-    NSString *deepLinkString    = [NSString stringWithFormat:@"/%@%@",
+    NSString *deepLinkString    = [NSString stringWithFormat:@"%@%@",
                                    deepLink.URL.host, deepLink.URL.path];
     NSArray *matches            = [self.regex matchesInString:deepLinkString
                                                       options:0

--- a/DeepLinkSDK/RouteMatcher/DPLRouteMatcher.m
+++ b/DeepLinkSDK/RouteMatcher/DPLRouteMatcher.m
@@ -70,7 +70,8 @@ static NSString * const DPLURLParameterPattern = @"([^/]+)";
 - (DPLDeepLink *)deepLinkWithURL:(NSURL *)url {
     
     DPLDeepLink *deepLink       = [[DPLDeepLink alloc] initWithURL:url];
-    NSString *deepLinkString    = [deepLink.URL absoluteString];
+    NSString *deepLinkString    = [NSString stringWithFormat:@"/%@%@",
+                                   deepLink.URL.host, deepLink.URL.path];
     NSArray *matches            = [self.regex matchesInString:deepLinkString
                                                       options:0
                                                         range:NSMakeRange(0, deepLinkString.length)];

--- a/DeepLinkSDK/RouteMatcher/DPLRouteMatcher.m
+++ b/DeepLinkSDK/RouteMatcher/DPLRouteMatcher.m
@@ -3,7 +3,7 @@
 #import "NSString+DPLTrim.h"
 
 static NSString * const DPLRouteParameterPattern = @":[a-zA-Z0-9-_]+";
-static NSString * const DPLURLParameterPattern = @"([a-zA-Z0-9-_]+)";
+static NSString * const DPLURLParameterPattern = @"([^/]+)";
 
 @interface DPLRouteMatcher ()
 

--- a/Tests/RouteMatcher/DPLRouteMatcherSpec.m
+++ b/Tests/RouteMatcher/DPLRouteMatcherSpec.m
@@ -112,6 +112,14 @@ describe(@"Matching Routes", ^{
         DPLDeepLink *deepLink2 = [matcher deepLinkWithURL:url2];
         expect(deepLink2).notTo.beNil();
     });
+    
+    it(@"matches URLs with commas", ^{
+        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:@"TenDay/:weird_comma_path_thing"];
+        NSURL *url = [NSURL URLWithString:@"twcweather://TenDay/33.89,-84.46?aw_campaign=com.weather.TWC.TWCWidget"];
+        DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];
+        expect(deepLink.routeParameters[@"weird_comma_path_thing"]).to.equal(@"33.89,-84.46");
+        expect(deepLink).notTo.beNil();
+    });
 });
 
 SpecEnd


### PR DESCRIPTION
...123456789-._~:?#

Sorry I didn't try out the regex changes earlier but apps are actually using urls with commas in them (which are technically valid).

Ex: twcweather://TenDay/33.89,-84.46?aw_campaign=com.weather.TWC.TWCWidget