### PR TITLE
Add optional userInfo dictionary to route handlers

### DIFF
--- a/DeepLinkSDK/Protocols/DPLTargetViewControllerProtocol.h
+++ b/DeepLinkSDK/Protocols/DPLTargetViewControllerProtocol.h
@@ -11,7 +11,7 @@
  this method gets called. In that case, you might store the relevant data and configure its views
  in `-[UIViewController viewDidLoad]'.
  */
-- (void)configureWithDeepLink:(DPLDeepLink *)deepLink;
+- (void)configureWithDeepLink:(DPLDeepLink *)deepLink userInfo:(NSDictionary *)userInfo;
 
 @end
 

--- a/DeepLinkSDK/RouteHandler/DPLRouteHandler.h
+++ b/DeepLinkSDK/RouteHandler/DPLRouteHandler.h
@@ -21,9 +21,10 @@
 /**
  Indicates whether the deep link should be handled.
  @param deepLink A deep link instance.
+ @param userInfo A userInfo dictionary.
  @return YES to proceed with handling the deep link, otherwise NO. The default is YES.
  */
-- (BOOL)shouldHandleDeepLink:(DPLDeepLink *)deepLink;
+- (BOOL)shouldHandleDeepLink:(DPLDeepLink *)deepLink userInfo:(NSDictionary *)userInfo;
 
 
 /**
@@ -47,9 +48,10 @@
  @note The default implementation returns your application's root view controller.
  
  @param deepLink A deep link instance.
+ @param userInfo A userInfo dictionary.
  @return A view controller for presenting a target view controller.
  */
-- (UIViewController *)viewControllerForPresentingDeepLink:(DPLDeepLink *)deepLink;
+- (UIViewController *)viewControllerForPresentingDeepLink:(DPLDeepLink *)deepLink userInfo:(NSDictionary *)userInfo;
 
 
 /**

--- a/DeepLinkSDK/RouteHandler/DPLRouteHandler.m
+++ b/DeepLinkSDK/RouteHandler/DPLRouteHandler.m
@@ -2,7 +2,7 @@
 
 @implementation DPLRouteHandler
 
-- (BOOL)shouldHandleDeepLink:(DPLDeepLink *)deepLink {
+- (BOOL)shouldHandleDeepLink:(DPLDeepLink *)deepLink userInfo:(NSDictionary *)userInfo {
     return YES;
 }
 
@@ -17,7 +17,7 @@
 }
 
 
-- (UIViewController *)viewControllerForPresentingDeepLink:(DPLDeepLink *)deepLink {
+- (UIViewController *)viewControllerForPresentingDeepLink:(DPLDeepLink *)deepLink userInfo:(NSDictionary *)userInfo {
     return [UIApplication sharedApplication].keyWindow.rootViewController;
 }
 

--- a/DeepLinkSDK/Router/DPLDeepLinkRouter.h
+++ b/DeepLinkSDK/Router/DPLDeepLinkRouter.h
@@ -7,11 +7,12 @@
 /**
  Defines the block type to be used as the handler when registering a route.
  @param deepLink The deep link to be handled.
+ @param userInfo The userInfo dictionary passed in to the router.
  @note It is not strictly necessary to register block-based route handlers. 
  You can also register a class for a more structured approach.
  @see DPLDeepLinkRouteHandler
  */
-typedef void(^DPLRouteHandlerBlock)(DPLDeepLink *deepLink);
+typedef void(^DPLRouteHandlerBlock)(DPLDeepLink *deepLink, NSDictionary *userInfo);
 
 
 /**
@@ -59,7 +60,7 @@ typedef void(^DPLRouteCompletionBlock)(BOOL handled, NSError *error);
  @discussion You can also use the object literal syntax to register routes.
  For example, you can register a route handler block as follows:
  @code 
- deepLinkRouter[@"table/book/:id"] = ^(DPLDeepLink *deepLink) {
+ deepLinkRouter[@"table/book/:id"] = ^(DPLDeepLink *deepLink, NSDictionary *userInfo) {
     // Handle the link here.
  };
  @endcode
@@ -78,12 +79,13 @@ typedef void(^DPLRouteCompletionBlock)(BOOL handled, NSError *error);
 /**
  Attempts to handle an incoming URL.
  @param url The incoming URL from `application:didFinishLaunchingWithOptions:' or `application:openURL:sourceApplication:annotation:'
+ @param userInfo A userInfo dictionary to facilitate passing additional data to the route handler
  @param completionHandler A block executed after the deep link has been handled.
  @return YES if the incoming URL is handled, otherwise NO.
  
  @see DPLRouteCompletionBlock
  */
-- (BOOL)handleURL:(NSURL *)url withCompletion:(DPLRouteCompletionBlock)completionHandler;
+- (BOOL)handleURL:(NSURL *)url userInfo:(NSDictionary *)userInfo withCompletion:(DPLRouteCompletionBlock)completionHandler;
 
 
 
@@ -114,7 +116,7 @@ typedef void(^DPLRouteCompletionBlock)(BOOL handled, NSError *error);
  
  // or
  
- deepLinkRouter[@"table/book/:id"] = ^(DPLDeepLink *deepLink) {
+ deepLinkRouter[@"table/book/:id"] = ^(DPLDeepLink *deepLink, NSDictionary *userInfo) {
  // Handle the link here.
  }
  @endcode

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ self.router[@"/log/:message"] = ^(DPLDeepLink *link) {
   sourceApplication:(NSString *)sourceApplication
          annotation:(id)annotation {
 
-  [self.router handleURL:url withCompletion:NULL];
+  [self.router handleURL:url userInfo:nil withCompletion:NULL];
 
   return YES;
 }

--- a/SampleApps/ReceiverDemo/DPLReceiverAppDelegate.m
+++ b/SampleApps/ReceiverDemo/DPLReceiverAppDelegate.m
@@ -48,7 +48,7 @@
   sourceApplication:(NSString *)sourceApplication
          annotation:(id)annotation {
  
-    return [self.router handleURL:url withCompletion:NULL];
+    return [self.router handleURL:url userInfo:nil withCompletion:NULL];
 }
 
 @end

--- a/SampleApps/ReceiverDemo/ProductDetail/DPLProductDetailViewController.m
+++ b/SampleApps/ReceiverDemo/ProductDetail/DPLProductDetailViewController.m
@@ -23,7 +23,7 @@
 
 #pragma mark - DPLTargetViewController
 
-- (void)configureWithDeepLink:(DPLDeepLink *)deepLink {
+- (void)configureWithDeepLink:(DPLDeepLink *)deepLink userInfo:(NSDictionary *)userInfo {
     
     NSString *sku = deepLink.routeParameters[@"sku"];
     


### PR DESCRIPTION
This pull request adds an optional `userInfo` dictionary to the route handlers. This facilitates passing additional application-specific data to the route handler. For example, in the case of handling a deep link in a push notification payload, you could pass the payload itself to the handler as well as the URL.

The approach used here is to pass the user info as a second argument in addition to the deep link. I also experimented with adding the user info to the deep link, but that quickly became more complex. I think it makes sense to keep the deep link object focused on representing the link itself and for the user info to be isolated to the router and handlers.

I added a test to ensure that the user info gets passed to the block-based handler. Please advise if other tests are necessary.